### PR TITLE
Add new cask `svstudio2-pro` for Synthesizer V Studio 2 Pro.

### DIFF
--- a/Casks/s/svstudio2-pro.rb
+++ b/Casks/s/svstudio2-pro.rb
@@ -1,0 +1,22 @@
+cask "svstudio2-pro" do
+  version "2.0.7"
+  sha256 "c5bdeaee2e30bf15340c976fcffa0bed8e80c0b444fa18e0b509e169cb8c0985"
+
+  url "https://download.dreamtonics.com/svstudio2/svstudio2-pro-setup-latest.pkg"
+  name "Synthesizer V Studio 2 Pro"
+  desc "AI-based singing voice synthesis software"
+  homepage "https://dreamtonics.com/synthesizerv/"
+
+  pkg "svstudio2-pro-setup-latest.pkg"
+
+  uninstall pkgutil: [
+    "com.dreamtonics.svstudio2.pro",
+    "com.dreamtonics.svstudio2.auplugin",
+    "com.dreamtonics.svstudio2.vst3plugin",
+    "com.dreamtonics.svstudio2.aaxplugin"
+  ]
+
+  zap trash: [
+    "~/Library/Application Support/Dreamtonics/Synthesizer V Studio 2",
+  ]
+end

--- a/Casks/s/svstudio2-pro.rb
+++ b/Casks/s/svstudio2-pro.rb
@@ -18,5 +18,10 @@ cask "svstudio2-pro" do
 
   zap trash: [
     "~/Library/Application Support/Dreamtonics/Synthesizer V Studio 2",
+    "~/Library/Caches/com.dreamtonics.svstudio2.pro",
+    "~/Library/HTTPStorages/com.dreamtonics.svstudio2.pro",
+    "~/Library/HTTPStorages/com.dreamtonics.svstudio2.pro.binarycookies",
+    "~/Library/WebKit/com.dreamtonics.svstudio2.pro",
+    "~/Library/Preferences/com.dreamtonics.svstudio2.pro.plist",
   ]
 end


### PR DESCRIPTION
Synthesizer V Studio 2 Pro is a AI-based singing voice synthesis software. The homepage is [here](https://dreamtonics.com/synthesizerv/). 

This PR add a `.rb` cask for it.