### PR TITLE
config(migration): lyricsx-mxiris → mxiris-lyricsx

### DIFF
--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -1,0 +1,3 @@
+{
+	"lyricsx-mxiris": "mxiris-lyricsx"
+}


### PR DESCRIPTION
#921 将 `lyricsx-mxiris` 重命名为了 `mxiris-lyricsx`，为确保用户能够正确迁移，需要将名称映射关系写入仓库。

添加了 `tap_migrations.json` 文件后，Homebrew 能正确识别新旧名字。

```console
% brew info lyricsx-mxiris
==> mxiris-lyricsx ✔ (LyricsX): 1.8.9,10809999 (auto_updates)
Lyrics for iTunes, Spotify, Vox and Audirvana Plus
https://github.com/MxIris-LyricsX-Project/LyricsX
Installed (on request)
/opt/homebrew/Caskroom/mxiris-lyricsx/1.8.9,10809999 (21.1MB)
  Installed on 2026-07-19 at 23:31:14
From: https://github.com/brewforge/homebrew-extras/blob/HEAD/Casks/mxiris-lyricsx.rb
==> Requirements
Required: macOS >= 10.15 ✔
==> Artifacts
LyricsX.app (App)
```