### PR TITLE
Deprecate the `verified` parameter in the `url` stanza

### DIFF
--- a/Casks/b/barss.rb
+++ b/Casks/b/barss.rb
@@ -2,8 +2,7 @@ cask "barss" do
   version "1.6.2"
   sha256 "a26b3ae95a9c109f98a5cf8195d66cbb6a98f9bd8d8de1f4ad1932650acf2d1c"
 
-  url "https://github.com/relikd/baRSS/releases/download/v#{version}/baRSS_#{version}.zip",
-      verified: "github.com/relikd/baRSS/"
+  url "https://github.com/relikd/baRSS/releases/download/v#{version}/baRSS_#{version}.zip"
   name "baRSS"
   desc "Menu Bar RSS reader"
   homepage "https://relikd.de/projects/barss/"

--- a/Casks/b/buzz.rb
+++ b/Casks/b/buzz.rb
@@ -5,8 +5,7 @@ cask "buzz" do
   sha256 arm:   "db705058144c859e15d410e11a2b7a4b6faeb6994aab8e8101bd0bb5a05a06a8",
          intel: "14de05e47eabcf8a183baa2890b11eb2cde2369bfff992fd1375a8f051491e8d"
 
-  url "https://github.com/chidiwilliams/buzz/releases/download/v#{version}/Buzz-#{version}-mac-#{arch}.dmg",
-      verified: "github.com/chidiwilliams/buzz/"
+  url "https://github.com/chidiwilliams/buzz/releases/download/v#{version}/Buzz-#{version}-mac-#{arch}.dmg"
   name "Buzz"
   desc "Transcribe and translate audio offline on your personal computer"
   homepage "https://chidiwilliams.github.io/buzz"

--- a/Casks/c/cudatext.rb
+++ b/Casks/c/cudatext.rb
@@ -5,8 +5,7 @@ cask "cudatext" do
   sha256 arm:   "c97d2ac4450ad23fa3067c3e1ad428f450b89e337a53daa4d75cd07e19c4d864",
          intel: "a7fdfa222a9748dd9e3fc1fcf5d592c278b35f12625a4a9b599be8df73a4e692"
 
-  url "https://downloads.sourceforge.net/cudatext/release/#{version}/cudatext-macos-cocoa-#{arch}-#{version}.zip?viasf=1",
-      verified: "sourceforge.net/cudatext/"
+  url "https://downloads.sourceforge.net/cudatext/release/#{version}/cudatext-macos-cocoa-#{arch}-#{version}.zip?viasf=1"
   name "CudaText"
   desc "Text editor"
   homepage "https://cudatext.github.io/index.html"

--- a/Casks/c/cytoscape.rb
+++ b/Casks/c/cytoscape.rb
@@ -6,8 +6,7 @@ cask "cytoscape" do
          intel: "f1d898cc07ab0c74e02a559c97224e7f0fd84094e66f50f9e263c686efdae93c"
 
   version2 = version.tr(".", "_")
-  url "https://github.com/cytoscape/cytoscape/releases/download/#{version}/Cytoscape_#{version2}_macos_#{arch}.dmg",
-      verified: "github.com/cytoscape/cytoscape/"
+  url "https://github.com/cytoscape/cytoscape/releases/download/#{version}/Cytoscape_#{version2}_macos_#{arch}.dmg"
   name "Cytoscape"
   desc "Open source platform for network analysis and visualization"
   homepage "https://cytoscape.org/"

--- a/Casks/d/deskflow.rb
+++ b/Casks/d/deskflow.rb
@@ -5,8 +5,7 @@ cask "deskflow" do
   sha256 arm:   "bae6befc2c3119de3d751c1200aab30af3efa5496e91d5ca1029cc388eea69c5",
          intel: "b60bd78e829b9937c5812e6fc208b72a9235c3a5ba836601d50e1a5be9ac4af2"
 
-  url "https://github.com/deskflow/deskflow/releases/download/v#{version}/deskflow-#{version}-macos-#{arch}.dmg",
-      verified: "github.com/deskflow/deskflow/"
+  url "https://github.com/deskflow/deskflow/releases/download/v#{version}/deskflow-#{version}-macos-#{arch}.dmg"
   name "Deskflow"
   desc "Mouse and keyboard sharing utility"
   homepage "https://deskflow.org/"

--- a/Casks/g/goldendict-ng.rb
+++ b/Casks/g/goldendict-ng.rb
@@ -5,8 +5,7 @@ cask "goldendict-ng" do
   sha256 arm:   "2369c5bba5c68cd42061be8482813199c3fbe04e895616b62c4c3d5e7e233757",
          intel: "848823731819e21c615a3ca39c7b968b2af47bdc6df32ee7682026e2ed3422eb"
 
-  url "https://github.com/xiaoyifang/goldendict-ng/releases/download/v#{version.csv.first}/GoldenDict-ng-#{version.csv.first}-Qt#{version.csv.second}-macOS-#{arch}.dmg",
-      verified: "github.com/xiaoyifang/goldendict-ng/"
+  url "https://github.com/xiaoyifang/goldendict-ng/releases/download/v#{version.csv.first}/GoldenDict-ng-#{version.csv.first}-Qt#{version.csv.second}-macOS-#{arch}.dmg"
   name "GoldenDict"
   desc "Next Generation GoldenDict"
   homepage "https://xiaoyifang.github.io/goldendict-ng/"

--- a/Casks/g/gopeed-app.rb
+++ b/Casks/g/gopeed-app.rb
@@ -2,8 +2,7 @@ cask "gopeed-app" do
   version "1.9.3"
   sha256 "ebe7f39ef501deb3a55cd86e54f985a92872e215de50ea5ddbcbf9a02a2bd3cb"
 
-  url "https://github.com/GopeedLab/gopeed/releases/download/v#{version}/Gopeed-v#{version}-macos.dmg",
-      verified: "github.com/GopeedLab/gopeed/"
+  url "https://github.com/GopeedLab/gopeed/releases/download/v#{version}/Gopeed-v#{version}-macos.dmg"
   name "Gopeed"
   desc "High speed downloader that supports all platforms"
   homepage "https://gopeed.com/"

--- a/Casks/h/hiddify.rb
+++ b/Casks/h/hiddify.rb
@@ -2,8 +2,7 @@ cask "hiddify" do
   version "4.1.1"
   sha256 "2019c85aef259002909a088be7bfb28032bf9ce7f932ffa597fdfe3b4cbff914"
 
-  url "https://github.com/hiddify/hiddify-next/releases/download/v#{version}/Hiddify-MacOS.dmg",
-      verified: "github.com/hiddify/hiddify-next/"
+  url "https://github.com/hiddify/hiddify-next/releases/download/v#{version}/Hiddify-MacOS.dmg"
   name "Hiddify"
   desc "Multi-Platform Auto-Proxy Client"
   homepage "https://hiddify.com/"

--- a/Casks/i/imfile.rb
+++ b/Casks/i/imfile.rb
@@ -5,8 +5,7 @@ cask "imfile" do
   sha256 arm:   "1cb410aa683caea17da3d74467949f59e230276465ea4fd1efbf6134b4a783ff",
          intel: "ff3731599e4f70387852d548f7192daa708ca3789f82e0bfa8d33a6c846e355e"
 
-  url "https://github.com/imfile-io/imfile-desktop/releases/download/v#{version}/imFile-#{version}#{arch}.dmg",
-      verified: "github.com/imfile-io/imfile-desktop/"
+  url "https://github.com/imfile-io/imfile-desktop/releases/download/v#{version}/imFile-#{version}#{arch}.dmg"
   name "imFile"
   desc "Open-source download manager"
   homepage "https://imfile.io/"

--- a/Casks/m/muzik.rb
+++ b/Casks/m/muzik.rb
@@ -5,8 +5,7 @@ cask "muzik" do
   sha256 arm:   "dbdae8e6f99405c2da0ac553192fdab8ec0128871ce7ab7039ce99a212b504de",
          intel: "88c4086e5258e02afe13d65b7b98f3674949f8a4619b334d38d680c6a6328c2c"
 
-  url "https://github.com/muzik-apps/muzik-offline/releases/download/v#{version}/muzik-offline_#{version}_#{arch}.dmg",
-      verified: "github.com/muzik-apps/muzik-offline/"
+  url "https://github.com/muzik-apps/muzik-offline/releases/download/v#{version}/muzik-offline_#{version}_#{arch}.dmg"
   name "muzik"
   desc "Cross platform, local music player"
   homepage "https://muzik-apps.github.io/muzik-web/"

--- a/Casks/n/next-ai-drawio.rb
+++ b/Casks/n/next-ai-drawio.rb
@@ -5,8 +5,7 @@ cask "next-ai-drawio" do
   sha256 arm:   "d33c4ea32c4a51f6e6d0e1f8a322b4c751292fd84ae0b6ebd198920586fccbe9",
          intel: "c829735aac8c9be226a4e79f7b80d3e8d4fc85e3e40aa372ff7f23b1fb08f029"
 
-  url "https://github.com/DayuanJiang/next-ai-draw-io/releases/download/v#{version}/Next-AI-Draw.io-#{version}#{arch}.dmg",
-      verified: "github.com/DayuanJiang/next-ai-draw-io/"
+  url "https://github.com/DayuanJiang/next-ai-draw-io/releases/download/v#{version}/Next-AI-Draw.io-#{version}#{arch}.dmg"
   name "Next AI Draw.io"
   desc "AI-Powered Diagram Creation Tool - Chat, Draw, Visualize"
   homepage "https://next-ai-drawio.jiang.jp/"

--- a/Casks/n/notegen.rb
+++ b/Casks/n/notegen.rb
@@ -5,8 +5,7 @@ cask "notegen" do
   sha256 arm:   "2c198cd7a5f8316120b36a691e74487105e244b23a497c18a90b103b15a9a07b",
          intel: "e8c89c8f875e34b5abb54138561c669eeee0dce4d1ef43ad13fdee83b7574675"
 
-  url "https://github.com/codexu/note-gen/releases/download/note-gen-v#{version}/NoteGen_#{version}_#{arch}.dmg",
-      verified: "github.com/codexu/note-gen/"
+  url "https://github.com/codexu/note-gen/releases/download/note-gen-v#{version}/NoteGen_#{version}_#{arch}.dmg"
   name "NoteGen"
   desc "Application Bridging the Gap Between Recording and Writing with LLM"
   homepage "https://notegen.top/en/"

--- a/Casks/p/pearai.rb
+++ b/Casks/p/pearai.rb
@@ -2,8 +2,7 @@ cask "pearai" do
   version "1.8.9"
   sha256 :no_check
 
-  url "https://pearai-app.nyc3.digitaloceanspaces.com/PearAI-latest/darwin-arm64/PearAI-Installer.dmg",
-      verified: "pearai-app.nyc3.digitaloceanspaces.com/PearAI-latest/"
+  url "https://pearai-app.nyc3.digitaloceanspaces.com/PearAI-latest/darwin-arm64/PearAI-Installer.dmg"
   name "PearAI"
   desc "Open Source AI Code Editor"
   homepage "https://trypear.ai/"

--- a/Casks/p/peazip.rb
+++ b/Casks/p/peazip.rb
@@ -2,8 +2,7 @@ cask "peazip" do
   version "11.2.0"
   sha256 "8e354e950935b4cfbd25da71a80d18ad125ab204483ad41dd8dbb097d8f32a8e"
 
-  url "https://github.com/peazip/PeaZip/releases/download/#{version}/peazip-#{version}.DARWIN.aarch64.dmg",
-      verified: "github.com/peazip/PeaZip/"
+  url "https://github.com/peazip/PeaZip/releases/download/#{version}/peazip-#{version}.DARWIN.aarch64.dmg"
   name "Peazip"
   desc "Free Zip/Unzip software and Rar file extractor"
   homepage "https://peazip.github.io/"

--- a/Casks/r/rune-music.rb
+++ b/Casks/r/rune-music.rb
@@ -2,8 +2,7 @@ cask "rune-music" do
   version "2.0.0-alpha.9"
   sha256 "0e6797b280e9059765a02bc007d43b6ee1f1a6ab34b0616195b82298cfa79ef8"
 
-  url "https://github.com/Losses/rune/releases/download/v#{version}/Rune-v#{version}-macOS.dmg",
-      verified: "github.com/Losses/rune/"
+  url "https://github.com/Losses/rune/releases/download/v#{version}/Rune-v#{version}-macOS.dmg"
   name "Rune"
   desc "Player that blends classic design with modern technology"
   homepage "https://rune.not.ci/"

--- a/Casks/t/tinkertool.rb
+++ b/Casks/t/tinkertool.rb
@@ -2,8 +2,7 @@ cask "tinkertool" do
   version "11.4"
   sha256 "13c2d92e788e3cc7c90696261b638fcee5b3139f286eaa8fbea228a03de87ff4"
 
-  url "https://www.bresink.biz/download3.php?PHPSESSID=#{version.csv.second}",
-      verified: "bresink.biz/"
+  url "https://www.bresink.biz/download3.php?PHPSESSID=#{version.csv.second}"
   name "TinkerTool"
   desc "Gives you access to additional system preference settings"
   homepage "https://bresink.com/osx/TinkerTool.html"

--- a/Casks/t/tyx.rb
+++ b/Casks/t/tyx.rb
@@ -5,8 +5,7 @@ cask "tyx" do
   sha256 arm:   "3795544330c26760f4ea144a8a4edc8aa04908ccab39cdc3d8db80cb8dd9d53f",
          intel: "b58a945337fc7fa3a57df0b6404dc09fe10d9b6a4b83f7ec95b366d2e778229f"
 
-  url "https://github.com/tyx-editor/TyX/releases/download/v#{version}/TyX_#{version}_#{arch}.dmg",
-      verified: "github.com/tyx-editor/TyX/"
+  url "https://github.com/tyx-editor/TyX/releases/download/v#{version}/TyX_#{version}_#{arch}.dmg"
   name "TyX"
   desc "LyX-like experience rewritten for Typst and the modern era"
   homepage "https://tyx-editor.com/"

--- a/Casks/w/wpsoffice-en.rb
+++ b/Casks/w/wpsoffice-en.rb
@@ -9,8 +9,7 @@ cask "wpsoffice-en" do
   sha256 arm:   "7aa402cd41c3afbfe33a3b0b308b9c207bac02fef33649897993e3ead9c8fe5a",
          intel: "0de6b2f7cbb751a13db9ea9632c2038d52fd829be7fd3643b14f0e90ed40e8b0"
 
-  url "https://wdl1.pcfg.cache.wpscdn.com/wpsdl/macwpsoffice/download/installer/WPSOffice_#{arch}_#{channel}.dmg",
-      verified: "wdl1.pcfg.cache.wpscdn.com/"
+  url "https://wdl1.pcfg.cache.wpscdn.com/wpsdl/macwpsoffice/download/installer/WPSOffice_#{arch}_#{channel}.dmg"
   name "WPS Office"
   desc "AI-Powered Office Suite for Everyone"
   homepage "https://wps.com/"

--- a/Casks/y/ytdownloader.rb
+++ b/Casks/y/ytdownloader.rb
@@ -5,8 +5,7 @@ cask "ytdownloader" do
   sha256 arm:   "c43eb0cb39e9b21d4c9830df1635f75d8654b4942670f2e0081cf128b0b116ce",
          intel: "a49a6f307b6a9d0a10115ede1b090755e2d74510f9ac615ad6d51269fdf0a2cf"
 
-  url "https://github.com/aandrew-me/ytDownloader/releases/download/v#{version}/YTDownloader_Mac_#{arch}.dmg",
-      verified: "github.com/aandrew-me/ytDownloader/"
+  url "https://github.com/aandrew-me/ytDownloader/releases/download/v#{version}/YTDownloader_Mac_#{arch}.dmg"
   name "YTDownloader"
   desc "Desktop App for downloading Videos and Audios from hundreds of sites"
   homepage "https://ytdn.netlify.app/"


### PR DESCRIPTION
官方弃用了 `verified` 参数。

> Warning: Calling the `verified` parameter in the `url` stanza is deprecated! Use the default URL verification behaviour instead.