### PR TITLE
Disable symbol `:catalina`

### DIFF
--- a/Casks/c/chabox.rb
+++ b/Casks/c/chabox.rb
@@ -13,8 +13,8 @@ cask "chabox" do
     strategy :page_match
   end
 
-  depends_on macos: :catalina
-  
+  depends_on :macos
+
   app "ChaBox.app"
 
   zap trash: [

--- a/Casks/f/fileshows.rb
+++ b/Casks/f/fileshows.rb
@@ -13,7 +13,7 @@ cask "fileshows" do
     strategy :page_match
   end
 
-  depends_on macos: :catalina
+  depends_on :macos
 
   app "FileShows.app"
 

--- a/Casks/g/gai.rb
+++ b/Casks/g/gai.rb
@@ -13,7 +13,7 @@ cask "gai" do
     strategy :page_match
   end
 
-  depends_on macos: :catalina
+  depends_on :macos
 
   app "Gai.app"
 

--- a/Casks/m/mxiris-lyricsx.rb
+++ b/Casks/m/mxiris-lyricsx.rb
@@ -16,7 +16,7 @@ cask "mxiris-lyricsx" do
 
   auto_updates true
   conflicts_with cask: "lyricsx"
-  depends_on macos: :catalina
+  depends_on :macos
 
   app "LyricsX.app"
 


### PR DESCRIPTION
官方禁用了 `:catalina` 符号，允许在 macOS Catalina 及更低版本 macOS 上运行的 Cask 改为仅要求 `:macos` 而不特指定系统版本。